### PR TITLE
chore(deps): tilfoej Remotes for BFHcharts (v0.1.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHllm
 Title: LLM Integration Framework for BFH Packages
-Version: 0.1.1
+Version: 0.1.2
 Authors@R:
     person("Johan", "Reventlow", , "johan.reventlow@regionh.dk", role = c("aut", "cre"))
 Description: AI-driven insights and text generation for healthcare quality
@@ -26,4 +26,6 @@ Suggests:
     mockery,
     withr,
     BFHcharts (>= 0.4.0)
+Remotes:
+    johanreventlow/BFHcharts
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# BFHllm 0.1.2
+
+## Bug fixes
+
+* Tilføjet `Remotes:` for `BFHcharts` (Suggests). Downstream-installationer
+  kunne tidligere fejle ved `--as-cran` tests der forsøger at installere
+  Suggests. Fra v0.1.2 er transitiv dep-resolution konsistent med sibling-
+  pakkerne (BFHcharts v0.8.1).
+
 # BFHllm 0.1.1
 
 ## Bug fixes


### PR DESCRIPTION
Konsistent med BFHcharts v0.8.1: tilfoej Remotes-felt for BFHcharts (Suggests). Downstream-installationer med --as-cran kunne ikke finde BFHcharts transitivt. PATCH-bump (0.1.1 -> 0.1.2).