### PR TITLE
docs(readme): grundig revision mod faktisk kode (v0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,29 @@
 > LLM Integration Framework for BFH Packages
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![R-CMD-check](https://github.com/johanreventlow/BFHllm/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/johanreventlow/BFHllm/actions/workflows/R-CMD-check.yaml)
+[![Version](https://img.shields.io/badge/version-0.2.0-blue.svg)](https://github.com/johanreventlow/BFHllm/blob/main/NEWS.md)
 
 ## Overview
 
-BFHllm provides AI-driven insights and text generation for healthcare quality improvement. The package offers:
+BFHllm provides AI-driven insights and text generation for healthcare quality
+improvement. It wraps the Google Gemini API (via [ellmer](https://github.com/hadley/ellmer))
+behind a stable, resilient interface and adds SPC-specific knowledge and prompting.
 
-- **LLM Chat Interface** - Generic chat function with provider abstraction
-- **RAG Integration** - Retrieval Augmented Generation with knowledge stores
-- **SPC-Specific Suggestions** - Improvement suggestions for Statistical Process Control charts
-- **Circuit Breaker** - Resilient API calls with automatic failure handling
-- **Caching** - Session-scoped response caching for Shiny applications
+Key capabilities:
 
-Designed for standalone use with [BFHcharts](https://github.com/johanreventlow/BFHcharts) or integration in Shiny applications like [SPCify](https://github.com/johanreventlow/claude_spc).
+- **LLM chat interface** — generic chat function with provider abstraction
+- **RAG integration** — Retrieval Augmented Generation against a pre-built
+  Ragnar knowledge store of SPC methodology
+- **SPC suggestions** — Danish improvement suggestions for Statistical Process
+  Control charts, single or batched
+- **Resilience** — circuit breaker + client-side rate limiter (RPM/RPD) to
+  protect against API failures and quota exhaustion
+- **Multi-tier caching** — in-memory, file-based, and Shiny session-scoped
+- **YAML-driven prompts** — SPC prompt templates externalised to YAML
+
+Designed for standalone use with [BFHcharts](https://github.com/johanreventlow/BFHcharts)
+or integration in Shiny applications like [SPCify](https://github.com/johanreventlow/claude_spc).
 
 ## Installation
 
@@ -23,29 +34,43 @@ Designed for standalone use with [BFHcharts](https://github.com/johanreventlow/B
 remotes::install_github("johanreventlow/BFHllm")
 ```
 
+Requires R, a Google Gemini API key, and the `ellmer` / `ragnar` packages
+(resolved automatically). `BFHcharts` is a soft dependency used only for the
+SPC integration examples.
+
 ## Quick Start
 
-### Basic Chat
+Set the API key once (e.g. in `.Renviron`):
+
+```r
+Sys.setenv(GOOGLE_API_KEY = "your_api_key")  # or GEMINI_API_KEY
+```
+
+### Basic chat
 
 ```r
 library(BFHllm)
 
-# Set API key
-# Sys.setenv(GOOGLE_API_KEY = "your_api_key")
+# Quick availability check (API key + provider)
+bfhllm_chat_available()
 
-# Simple chat
 response <- bfhllm_chat(
-  prompt = "Explain statistical process control in 2 sentences"
+  prompt = "Explain statistical process control in 2 sentences",
+  max_chars = 200
 )
 ```
 
-### SPC Suggestions (with BFHcharts)
+`bfhllm_chat()` returns `NULL` on any error (timeout, API failure, validation
+failure) rather than throwing — check the result and inspect
+`bfhllm_circuit_breaker_status()` if needed.
+
+### SPC suggestions (with BFHcharts)
 
 ```r
 library(BFHcharts)
 library(BFHllm)
 
-# Create SPC chart
+# Create an SPC chart
 bfh_result <- bfh_qic(
   data = spc_data,
   x = date,
@@ -55,13 +80,13 @@ bfh_result <- bfh_qic(
   target_value = 30
 )
 
-# Build metadata structure for BFHllm
+# Build the metadata structure BFHllm expects (English keys)
 spc_result <- list(
   metadata = list(
     chart_type = bfh_result$config$chart_type,
     n_points = nrow(bfh_result$qic_data),
     signals_detected = sum(bfh_result$summary$løbelængde_signal,
-                          bfh_result$summary$sigma_signal, na.rm = TRUE),
+                           bfh_result$summary$sigma_signal, na.rm = TRUE),
     anhoej_rules = list(
       longest_run = bfh_result$summary$længste_løb,
       n_crossings = bfh_result$summary$antal_kryds,
@@ -71,7 +96,7 @@ spc_result <- list(
   qic_data = bfh_result$qic_data
 )
 
-# Define context
+# Domain context for the prompt
 context <- list(
   data_definition = "Ventetid til operation (dage)",
   chart_title = "Ventetid ortopædkirurgi 2023-2024",
@@ -79,7 +104,7 @@ context <- list(
   target_value = 30
 )
 
-# Get AI-driven improvement suggestion (with RAG)
+# Generate a Danish, RAG-enhanced improvement suggestion
 suggestion <- bfhllm_spc_suggestion(
   spc_result = spc_result,
   context = context,
@@ -89,74 +114,172 @@ suggestion <- bfhllm_spc_suggestion(
 print(suggestion)
 ```
 
-**Full example:** See `inst/examples/bfhcharts-integration.R` for complete standalone integration including caching and RAG comparison.
+**Full example:** see `inst/examples/bfhcharts-integration.R` for complete
+standalone integration including caching and a RAG vs. no-RAG comparison.
 
-### RAG-Enhanced Chat
+### RAG-enhanced chat
 
 ```r
-# Load knowledge store
+# Load the pre-built SPC knowledge store (cached after first load)
 store <- bfhllm_load_knowledge_store()
 
-# Query with RAG context
 response <- bfhllm_chat_with_rag(
-  prompt = "What does a long run above centerline indicate?",
-  knowledge_query = "Anhøj rules run chart interpretation",
-  store = store
+  question = "What does a long run above the centerline indicate?",
+  store    = store,
+  top_k    = 5,
+  method   = "hybrid"   # "hybrid" | "semantic" | "bm25"
+)
+```
+
+### Batch SPC suggestions
+
+```r
+# Analyse many charts in one pass; file-cached to avoid repeat API calls
+suggestions <- bfhllm_spc_suggestions_batch(
+  contexts   = list_of_spc_contexts,
+  batch_size = 25L,
+  use_cache  = TRUE
 )
 ```
 
 ## Features
 
-### Circuit Breaker
+### Circuit breaker
 
 Automatic protection against API failures:
-- Opens after threshold failures (default: 5)
-- Auto-resets after timeout (default: 5 minutes)
-- Prevents cascading failures
+
+- Opens after a threshold of consecutive failures (default: **5**)
+- Auto-resets after a timeout (default: **300 s** / 5 minutes)
+- Inspect with `bfhllm_circuit_breaker_status()`, force reset with
+  `bfhllm_circuit_breaker_reset()`
+
+### Rate limiting
+
+Client-side limiter that respects Gemini free-tier quotas:
+
+- **RPM** (requests per minute): 15 by default
+- **RPD** (requests per day): 1500 by default
+- Configurable via `bfhllm_configure(rate_limit = list(...))`
+- Inspect with `bfhllm_rate_limit_status()`, reset with `bfhllm_rate_limit_reset()`
 
 ### Caching
 
-Reduce API calls and costs:
-- Hash-based cache keys
-- TTL enforcement (default: 1 hour)
-- Session-scoped for Shiny apps
-- Generic interface for standalone use
+Three interchangeable cache backends reduce API calls and cost:
 
-### Provider Abstraction
+| Backend | Constructor | Scope | Persists across sessions |
+|---|---|---|---|
+| In-memory | `bfhllm_cache_create()` | R process | No |
+| File-based | `bfhllm_file_cache_create()` | disk (`.bfhllm_cache/`) | Yes |
+| Shiny session | `bfhllm_cache_shiny()` | Shiny session | No (cleared on disconnect) |
 
-Currently supports Google Gemini via [ellmer](https://github.com/hadley/ellmer). Extensible design allows future providers (OpenAI, Anthropic, etc.).
+All backends use hash-based keys and TTL enforcement (default: 3600 s).
+Pass a cache object to `bfhllm_chat()` / `bfhllm_spc_suggestion()` via `cache =`.
+
+### Provider abstraction
+
+Currently supports Google Gemini via
+[ellmer](https://github.com/hadley/ellmer). The extensible design (see
+`list_providers()`) allows future providers (OpenAI, Anthropic, local models).
+
+## Function reference
+
+| Function | Purpose |
+|---|---|
+| **Chat** | |
+| `bfhllm_chat()` | Generic LLM chat with caching, circuit breaker & validation |
+| `bfhllm_chat_available()` | Quick check that chat is usable (key + provider) |
+| **RAG** | |
+| `bfhllm_chat_with_rag()` | RAG-enhanced chat (retrieve → inject → generate) |
+| `bfhllm_query_knowledge()` | Query the knowledge store for relevant context |
+| `bfhllm_format_rag_context()` | Format RAG results into a prompt context string |
+| `bfhllm_load_knowledge_store()` | Load the pre-built Ragnar store (session-cached) |
+| `bfhllm_build_knowledge_store()` | Build a store from markdown documents |
+| `bfhllm_reset_knowledge_store_cache()` | Clear cached store (testing / reload) |
+| **SPC suggestions** | |
+| `bfhllm_spc_suggestion()` | Danish improvement suggestion for one chart |
+| `bfhllm_spc_suggestions_batch()` | Batched suggestions for many charts (file-cached) |
+| `bfhllm_extract_spc_metadata()` | Extract metadata from BFHcharts/qicharts2 results |
+| `bfhllm_map_chart_type_danish()` | Translate chart-type codes to Danish names |
+| **Prompts** | |
+| `bfhllm_build_prompt()` | Concatenate modular prompt components |
+| `bfhllm_create_structured_prompt()` | Build a structured question/context/system prompt |
+| `bfhllm_interpolate()` | Fill `{{variable}}` placeholders in a template |
+| **Caching** | |
+| `bfhllm_cache_create()` | In-memory cache |
+| `bfhllm_file_cache_create()` | Disk-backed cache (survives sessions) |
+| `bfhllm_cache_shiny()` | Shiny session-scoped cache |
+| `bfhllm_generate_cache_key()` | Hash arbitrary inputs into a cache key |
+| **Configuration** | |
+| `bfhllm_configure()` | Set provider, model, timeouts, circuit breaker, rate limit, cache |
+| `bfhllm_get_config()` | Current config with env-var fallbacks |
+| `bfhllm_validate_setup()` | Check all prerequisites are met |
+| **Resilience** | |
+| `bfhllm_circuit_breaker_status()` / `_reset()` | Inspect / reset circuit breaker |
+| `bfhllm_rate_limit_status()` / `_reset()` | Inspect / reset rate limiter |
+| **Providers & validation** | |
+| `list_providers()` | List registered LLM providers |
+| `validate_response()` / `validate_response_length()` | Sanitise & length-check responses |
 
 ## Configuration
 
 ```r
-# Configure LLM settings
 bfhllm_configure(
-  provider = "gemini",
-  model = "gemini-3.1-flash-lite",
-  timeout_seconds = 120,
-  max_response_chars = 350
+  provider           = "gemini",
+  model              = "gemini-3.1-flash-lite",
+  timeout_seconds    = 120,
+  max_response_chars = 350,
+  circuit_breaker    = list(failure_threshold = 5, reset_timeout_seconds = 300),
+  rate_limit         = list(enabled = TRUE, rpm = 15, rpd = 1500)
 )
 
-# Check setup
+# Inspect current configuration
+bfhllm_get_config()
+
+# Verify prerequisites (API key, provider, dependencies)
 bfhllm_validate_setup()
 ```
 
-## Environment Variables
+| Setting | Default | Description |
+|---|---|---|
+| `provider` | `"gemini"` | LLM provider |
+| `model` | `"gemini-3.1-flash-lite"` | Model identifier |
+| `timeout_seconds` | `120` | API timeout |
+| `max_response_chars` | `350` | Maximum response length |
+| `circuit_breaker$failure_threshold` | `5` | Failures before the breaker opens |
+| `circuit_breaker$reset_timeout_seconds` | `300` | Auto-reset window |
+| `cache$ttl_seconds` | `3600` | Cache entry time-to-live |
+| `rate_limit$rpm` / `$rpd` | `15` / `1500` | Requests per minute / day |
 
-- `GOOGLE_API_KEY` or `GEMINI_API_KEY` - API key for Gemini
-- `BFHLLM_MODEL` - Default model (optional)
-- `BFHLLM_TIMEOUT` - Default timeout in seconds (optional)
+## Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `GOOGLE_API_KEY` or `GEMINI_API_KEY` | Gemini API key (either is accepted) |
+| `BFHLLM_MODEL` | Override the default model |
+| `BFHLLM_TIMEOUT` | Override the default timeout (seconds) |
 
 ## Development
 
-This package was extracted from [SPCify](https://github.com/johanreventlow/claude_spc) to enable standalone use with BFHcharts and future applications.
+This package was extracted from
+[SPCify](https://github.com/johanreventlow/claude_spc) to enable standalone use
+with BFHcharts and future applications.
 
-### Related Packages
+```r
+devtools::load_all()   # Load for interactive testing
+devtools::document()   # Regenerate docs + NAMESPACE
+devtools::test()       # Run the test suite
+devtools::check()      # Full R CMD check
+```
 
-- [BFHcharts](https://github.com/johanreventlow/BFHcharts) - SPC visualization engine
-- [BFHtheme](https://github.com/johanreventlow/BFHtheme) - Hospital branding and themes
-- [ragnar](https://github.com/edubruell/ragnar) - RAG knowledge store framework
-- [ellmer](https://github.com/hadley/ellmer) - Gemini API client
+Runnable usage examples live in `inst/examples/` (`basic-chat.R`,
+`bfhcharts-integration.R`, `spc-suggestion.R`, `shiny-integration.R`).
+
+### Related packages
+
+- [BFHcharts](https://github.com/johanreventlow/BFHcharts) — SPC visualization engine
+- [BFHtheme](https://github.com/johanreventlow/BFHtheme) — hospital branding and themes
+- [ragnar](https://github.com/edubruell/ragnar) — RAG knowledge store framework
+- [ellmer](https://github.com/hadley/ellmer) — Gemini API client
 
 ## License
 
@@ -164,6 +287,4 @@ MIT © Johan Reventlow
 
 ## Status
 
-**In Development** - v0.1.0 targeting initial release
-
-See [implementation tracking](https://github.com/johanreventlow/claude_spc/issues/99) for progress.
+**v0.2.0** — production. See [NEWS.md](NEWS.md) for the changelog.


### PR DESCRIPTION
## Summary
- README var stale ift. v0.1.0; revideret mod verificeret kodelæsning af `R/`, `NAMESPACE`, `DESCRIPTION`
- Dokumenteret tidligere usynlige features: rate limiter (RPM 15 / RPD 1500), batch SPC-suggestions, fil-baseret cache, YAML-prompts
- Tilføjet function-reference-tabel med alle 29 exports grupperet; config- + env-var-tabeller med verificerede defaults
- Rettet stale RAG-eksempel (`question=`/`store=`/`method=`, ikke `prompt=`/`knowledge_query=`) + R-CMD-check/version-badges

## Verificering
- Alle 29 NAMESPACE-exports refereret i README
- 4 eksempel-stier i `inst/examples/` bekræftet eksisterende
- Version synket med DESCRIPTION (0.2.0)
- Circuit-breaker-tal (5 / 300s) bekræftet korrekte mod `R/config.R`

## Scope
- Kun `README.md` ændret — ingen kode-ændringer i `R/`
- Pre-eksisterende urelaterede `.claude/`-ændringer bevidst ikke inkluderet

## Test plan
- [ ] Visuel gennemlæsning af renderet README på GitHub
- [ ] Bekræft badge-links resolver (R-CMD-check workflow)