### PR TITLE
fix(version): synkronisér DESCRIPTION Version med v0.2.1-tag

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BFHllm
 Title: LLM Integration Framework for BFH Packages
-Version: 0.2.0
+Version: 0.2.1
 Authors@R:
     person("Johan", "Reventlow", , "johan.reventlow@regionh.dk", role = c("aut", "cre"))
 Description: AI-driven insights and text generation for healthcare quality

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# BFHllm 0.2.1
+
+## Interne ændringer
+
+* Grundig revision af README mod faktisk kode.
+* Rettet Version-drift: `tag-release.yaml` auto-tagger PATCH ved hver
+  merge til `main` uden at bumpe `DESCRIPTION`'s `Version:`-felt, så
+  taggen (v0.2.1) og pakkens rapporterede version (0.2.0) var kommet ud
+  af sync. Downstream-forbrugere der installerer fra `@v0.2.1` fik derfor
+  en pakke der selv rapporterede 0.2.0. Workflowets grundlæggende adfærd
+  er uændret i denne commit — kun DESCRIPTION er bragt i sync med tagget.
+
 # BFHllm 0.2.0
 
 ## Nye features


### PR DESCRIPTION
## Summary

- `tag-release.yaml` auto-inkrementerer PATCH-tagget ved hver merge til `main`, men committer ikke det bumpede versionsnummer tilbage til `DESCRIPTION`
- `v0.2.1`-tagget (README-revision, #10) blev derfor sat på en commit hvor `DESCRIPTION` stadig rapporterede `Version: 0.2.0`
- Opdaget fra biSPCharts-siden: `publish_prepare.R install` installerede `@v0.2.1`, men `packageVersion('BFHllm')` returnerede `0.2.0` — fik `dev/validate_connect_manifest.R` til at fejle
- Denne PR retter kun symptomet (DESCRIPTION bragt i sync med tagget + NEWS-entry tilføjet). Selve gap'et i `tag-release.yaml` (committer ikke DESCRIPTION-bump tilbage efter tagging) er ikke rettet her — værd at overveje separat, hvis PATCH-only merges skal blive ved med at trigge auto-tagging uden manuelt DESCRIPTION-bump.

## Test plan

- [x] `git diff v0.2.0..v0.2.1` bekræftet: kun README.md ændret, ingen kodeændringer
- [ ] R-CMD-check kører automatisk på PR